### PR TITLE
Make manip.py 3000X faster

### DIFF
--- a/manip.py
+++ b/manip.py
@@ -5,6 +5,7 @@ import tqdm
 import multiprocessing as mp
 from bitstring import ConstBitStream
 from PIL import Image
+import numpy as np
 
 # 70
 # 80

--- a/manip.py
+++ b/manip.py
@@ -54,6 +54,26 @@ def processing(params):
     return hold
     #print("{0} : [{1},{2}]".format(average,pI,pJ)) # DEBUG
 
+def processing2(params):
+    pStamp = params[0]
+    pI = params[1]
+    pJ = params[2]
+    VER = params[3]
+    HOR = params[4]
+    PXLS = params[5]
+    
+    fname = 'SAMPLE_{0}_{1}_{2}.dmp'.format(pStamp, str(pI), str(pJ) )
+
+    tech = np.fromfile(fname, "float32")
+
+    ## DATA MANIP START
+    average = tech.mean()
+    
+    colour = int( (average/100)*255 )
+    hold = [ pStamp, pI, pJ, VER, HOR, colour ]
+    del(tech)
+    return hold
+
 
 if __name__ == '__main__':
     
@@ -73,7 +93,7 @@ if __name__ == '__main__':
     pewl = mp.Pool(3)
     print("processing...")
 
-    for PXL in tqdm.tqdm(pewl.imap_unordered(processing, DUMPS), total=len(DUMPS)):
+    for PXL in tqdm.tqdm(pewl.imap_unordered(processing2, DUMPS), total=len(DUMPS)):
         # correcting for even vertical pixel data being generated
         # from and upward sweep of the antenna, and vice versa for the odd case
         if PXL[1]/2 == PXL[1]/2.0:

--- a/time_test.py
+++ b/time_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import numpy as np
+from bitstring import ConstBitStream
+import time
+
+data = np.arange(0, 1000000, 0.1).astype('float32')
+
+data.tofile("test.dat")
+
+
+
+def old_way(fname):
+    f = open(fname, 'rb')
+    read = handleDump(f)
+    f.close()
+    return read
+
+def handleDump(fileObj):
+    tech = []
+    raw = ConstBitStream(fileObj)
+    try:
+        while True:
+            tech.append(raw.read('floatle:32'))
+    except:
+        pass
+    del(raw)
+    return tech 
+
+
+def numpy_way(fname):
+    return np.fromfile(fname, "float32")
+
+def time_millis():
+    return int(round(time.time() * 1000))
+
+
+numpy_start = time_millis()
+np_dat = numpy_way("test.dat")
+numpy_end = time_millis()
+
+old_start = time_millis()
+old_dat = old_way("test.dat")
+old_end = time_millis()
+
+
+print("Numpy: %10i ms"%(numpy_end-numpy_start))
+print("  Old: %10i ms"%(old_end-old_start))
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Hey guys,

I do a lot of data processing in python and if there's one thing I've learned, it's that python is slow and numpy is fast.

Check out the time_test.py that I included. I think I matched your data format because I was able to use handleDump to parse my test file. In any case, for a file that contained 10M float32, handleDump took 68,000 ms while numpy only took 21 ms.

I'm not sure what errors you're catching with your try-except. But surely you'll be able to catch them in a different way with the extra hour of time you'll save :P

Anyways, I don't recommend merging this pull request. But take a look at my version of manip.py. Switching in numpy should make things a lot faster. 